### PR TITLE
fix: Corrección de timezones en pronostico/card

### DIFF
--- a/app/app/(form)/actions.ts
+++ b/app/app/(form)/actions.ts
@@ -61,6 +61,7 @@ export async function Submit(
       data: {
         day,
         date,
+        dateTz: clima.timezone,
         userId: user?.id,
         lower: lowerSelected,
         upper: upperSelected,

--- a/app/app/infobar.tsx
+++ b/app/app/infobar.tsx
@@ -62,8 +62,10 @@ export default async function Infobar(): Promise<JSX.Element> {
                 key={weather.dt}
                 className="rounded-lg flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-black/20 px-1 py-6 sm:px-6 xl:px-8 text-white"
               >
-                <dt className="text-sm font-medium leading-6  ">
-                  {getHour(new Date(weather.dt * 1000))}
+                <dt className="text-sm font-medium leading-6">
+                  {getHour(
+                    new Date(weather.dt * 1000 + forecast.city.timezone * 1000)
+                  )}
                 </dt>
                 <dd
                   className={classNames(

--- a/app/app/pronostico/page.tsx
+++ b/app/app/pronostico/page.tsx
@@ -59,7 +59,11 @@ export default async function Pronostico(): Promise<JSX.Element> {
                   className="rounded-lg flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-black/20 px-1 py-2 pb-4 sm:px-6 xl:px-8 text-white"
                 >
                   <dt className="text-sm font-medium leading-6  ">
-                    {getHour(new Date(weather.dt * 1000))}
+                    {getHour(
+                      new Date(
+                        weather.dt * 1000 + forecast.city.timezone * 1000
+                      )
+                    )}
                   </dt>
                   <dd
                     className={classNames(

--- a/app/app/respuestas/card.tsx
+++ b/app/app/respuestas/card.tsx
@@ -8,9 +8,13 @@ export default function ReportCard({
 }: {
   report: Report;
 }): JSX.Element {
-  const formattedDate = getDay(report.date);
+  const formattedDate = getDay(
+    new Date(report.date.getTime() + report.dateTz * 1000)
+  );
 
-  const formattedHour = getHour(report.date);
+  const formattedHour = getHour(
+    new Date(report.date.getTime() + report.dateTz * 1000)
+  );
 
   const upper = Clothes.Upper[report.upper as UpperType];
   const lower = Clothes.Lower[report.lower as LowerType];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.2-1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "que-me-pongo",
-      "version": "0.3.2-1",
+      "version": "0.4.0",
       "dependencies": {
         "@auth/prisma-adapter": "^1.0.2",
         "@headlessui/react": "^1.7.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "que-me-pongo",
-  "version": "0.4.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "que-me-pongo",
-      "version": "0.4.0",
+      "version": "0.3.2",
       "dependencies": {
         "@auth/prisma-adapter": "^1.0.2",
         "@headlessui/react": "^1.7.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.2-0",
+  "version": "0.3.2-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "que-me-pongo",
-      "version": "0.3.2-0",
+      "version": "0.3.2-1",
       "dependencies": {
         "@auth/prisma-adapter": "^1.0.2",
         "@headlessui/react": "^1.7.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.1",
+  "version": "0.3.2-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "que-me-pongo",
-      "version": "0.3.1",
+      "version": "0.3.2-0",
       "dependencies": {
         "@auth/prisma-adapter": "^1.0.2",
         "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.2-0",
+  "version": "0.3.2-1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.2-1",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "que-me-pongo",
-  "version": "0.3.1",
+  "version": "0.3.2-0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "que-me-pongo",
-  "version": "0.4.0",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20231001005925_report_add_timezone/migration.sql
+++ b/prisma/migrations/20231001005925_report_add_timezone/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Report" ADD COLUMN     "dateTz" INTEGER NOT NULL DEFAULT 10800;

--- a/prisma/migrations/20231001010201_change_timezone_from_3_to_3/migration.sql
+++ b/prisma/migrations/20231001010201_change_timezone_from_3_to_3/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Report" ALTER COLUMN "dateTz" SET DEFAULT -10800;

--- a/prisma/migrations/20231001010202_change_all_reports_to_GMT-3/migration.sql
+++ b/prisma/migrations/20231001010202_change_all_reports_to_GMT-3/migration.sql
@@ -1,0 +1,4 @@
+-- Update ALL
+-- Cambiar todos los reportes a la timezone de buenos aires
+
+UPDATE "Report" SET "dateTz" = -10800;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Report {
   temp   Float
   userId String
   date   DateTime @default(now())
+  dateTz Int @default(-10800) // Timezone shift from UTC expressed in seconds. Default is Buenos Aires (GMT-3) 3 * 60 * 60 -> 3 hours in seconds
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Segun este bug: https://www.reddit.com/r/nextjs/comments/12m8nzi/the_server_and_client_components_in_vercel_next/ los componentes de servidor consideran la timezone UTC (ya que el servidor lo tiene configurado así) pero los client components toman la del dispositivo del usuario.

Por eso a veces habia diferencias entre los horarios mostrados en pantalla.

Este PR mete en la cuenta de calculo de hora este cambio para los Server Components.