### PR TITLE
hotfix: Manejo de Avisos si localStorage no tiene nada

### DIFF
--- a/app/(components)/aviso-banner.tsx
+++ b/app/(components)/aviso-banner.tsx
@@ -13,14 +13,20 @@ export default function AvisoBanner({ aviso }: { aviso: string }): JSX.Element {
     if (hideAvisoStg === 'false') {
       setHideAviso(false);
     }
+    if (hideAvisoStg === null) {
+      localStorage.setItem('hideAviso', 'false');
+      setHideAviso(false);
+    }
   }, []);
 
   React.useEffect(() => {
     const lastAviso = localStorage.getItem('lastAviso');
     if (lastAviso && lastAviso !== aviso) {
-      console.info('Actualizando referencia al Aviso');
       setHideAviso(false);
       localStorage.setItem('hideAviso', 'false');
+      localStorage.setItem('lastAviso', aviso);
+    }
+    if (lastAviso === null) {
       localStorage.setItem('lastAviso', aviso);
     }
   }, [hideAviso, aviso]);


### PR DESCRIPTION
- Si el usuario nunca habia tenido anteriormente un Aviso, no se mostraba ya que el hideAviso nunca se ponía en false